### PR TITLE
change parent for <uses-permission>

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -68,7 +68,7 @@
             <string name="cr_app_id">$ANDROID_APP_ID</string>
         </config-file>
 
-        <config-file target="AndroidManifest.xml" parent="application">
+        <config-file target="AndroidManifest.xml" parent="/manifest">
             <meta-data android:name="com.crittercism.sdk.ApplicationId" android:value="@string/cr_app_id"/>
             <!-- PhoneGap adds the INTERNET permission by itself -->
             <uses-permission android:name="android.permission.READ_LOGS"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -68,7 +68,7 @@
             <string name="cr_app_id">$ANDROID_APP_ID</string>
         </config-file>
 
-        <config-file target="AndroidManifest.xml" parent="/manifest">
+        <config-file target="AndroidManifest.xml" parent="/*">
             <meta-data android:name="com.crittercism.sdk.ApplicationId" android:value="@string/cr_app_id"/>
             <!-- PhoneGap adds the INTERNET permission by itself -->
             <uses-permission android:name="android.permission.READ_LOGS"/>


### PR DESCRIPTION
- When doing `cordova build --release android`
- Following error was thrown
  "The <uses-permission> element must be a direct child of the <manifest> root element [WrongManifestParent]"
- This happened after updating cordova(5.0.0) and android sdk ( Revision 24.2.0 ) .