### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cordova-plugin-crittercism",
+  "version": "3.0.1",
+  "description": "The Crittercism plugin is available for iOS and Android.",
+  "repository": "crittercism/PhoneGap",
+  "keywords": [
+    "cordova",
+    "cordova-android",
+    "cordova-ios",
+    "crittercism",
+    "ecosystem:cordova"
+  ],
+  "license": "Apache-2.0",
+  "bugs": "https://github.com/crittercism/PhoneGap/issues",
+  "homepage": "http://docs.crittercism.com/development_platforms/phonegap.html"
+}


### PR DESCRIPTION
Hi guys,

I added a `package.json` so that you can easily publish your package on npm, which is now used as a plugin repository by Cordova. Just run `npm publish` and you should be good to go.

Closes #16