### PR TITLE
Agnt 1398 App ID

### DIFF
--- a/platforms/android/com/crittercism/plugin/CDVCrittercism.java
+++ b/platforms/android/com/crittercism/plugin/CDVCrittercism.java
@@ -57,16 +57,22 @@ public class CDVCrittercism extends CordovaPlugin {
         Context context = this.cordova.getActivity();
         packageName = context.getPackageName();
         Resources resources = context.getResources();
-        String crAppID = context.getString(resources.getIdentifier(
-                APPLICATION_ID, STRING, packageName));
-        Crittercism.initialize(context, crAppID);
+        int identifier = resources.getIdentifier(APPLICATION_ID, STRING, packageName);
+        if (identifier != 0) {
+            String crAppID = context.getString(identifier);
+            if (crAppID != null && !crAppID.isEmpty()) {
+                Crittercism.initialize(context, crAppID);
+            }
+        }
     }
 
     @Override
     public boolean execute(String action, final JSONArray args,
                            CallbackContext callbackContext) throws JSONException {
         try {
-            if (ACTION_ADD_BREADCRUMB.equals(action)) {
+            if (ACTION_INIT.equals(action)) {
+                return executeInit(action, args, callbackContext);
+            } else if (ACTION_ADD_BREADCRUMB.equals(action)) {
                 return executeLeaveBreadcrumb(action, args, callbackContext);
             } else if (ACTION_SET_USERNAME.equals(action)) {
                 return executeSetUsername(action, args, callbackContext);
@@ -98,6 +104,15 @@ public class CDVCrittercism extends CordovaPlugin {
         }
     }
 
+    private boolean executeInit(String action, final JSONArray args,
+                               CallbackContext callbackContext) throws JSONException {
+        final JSONObject argsDict = args.getJSONObject(0);
+        final String appID = argsDict.getString("androidAppID");
+        Context context = this.cordova.getActivity();
+        Crittercism.initialize(context, appID);
+        return true;
+    }
+    
     private boolean executeLeaveBreadcrumb(String action, final JSONArray args,
                                CallbackContext callbackContext) throws JSONException {
         final String breadcrumb = args.getString(0);

--- a/platforms/android/com/crittercism/plugin/CDVCrittercism.java
+++ b/platforms/android/com/crittercism/plugin/CDVCrittercism.java
@@ -54,16 +54,6 @@ public class CDVCrittercism extends CordovaPlugin {
     @Override
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
-        Context context = this.cordova.getActivity();
-        packageName = context.getPackageName();
-        Resources resources = context.getResources();
-        int identifier = resources.getIdentifier(APPLICATION_ID, STRING, packageName);
-        if (identifier != 0) {
-            String crAppID = context.getString(identifier);
-            if (crAppID != null && !crAppID.isEmpty()) {
-                Crittercism.initialize(context, crAppID);
-            }
-        }
     }
 
     @Override

--- a/platforms/ios/CDVCrittercism.m
+++ b/platforms/ios/CDVCrittercism.m
@@ -31,11 +31,6 @@ static NSString *const CRJavascriptXMLHttpRequest = @"JavascriptXMLHttpRequest";
 
 - (void)pluginInitialize
 {
-  NSString *CritterAppID = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CritterAppID"];
-  if (CritterAppID.length) {
-    NSLog(@"Initializing Crittercism for application with app id %@", CritterAppID);
-    [Crittercism enableWithAppID:CritterAppID];  
-  }
 }
 
 - (void) crittercismInit:(CDVInvokedUrlCommand *)command {

--- a/platforms/ios/CDVCrittercism.m
+++ b/platforms/ios/CDVCrittercism.m
@@ -32,8 +32,19 @@ static NSString *const CRJavascriptXMLHttpRequest = @"JavascriptXMLHttpRequest";
 - (void)pluginInitialize
 {
   NSString *CritterAppID = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CritterAppID"];
-  NSLog(@"Initializing Crittercism for application with app id %@", CritterAppID);
-  [Crittercism enableWithAppID:CritterAppID];
+  if (CritterAppID.length) {
+    NSLog(@"Initializing Crittercism for application with app id %@", CritterAppID);
+    [Crittercism enableWithAppID:CritterAppID];  
+  }
+}
+
+- (void) crittercismInit:(CDVInvokedUrlCommand *)command {
+   [self.commandDelegate runInBackground:^{
+     NSDictionary* argsDict = command.arguments[0];
+     NSString* critterAppID = [argsDict objectForKey:@"iosAppID"];
+     NSLog(@"Initializing Crittercism for application with app id %@", critterAppID);
+     [Crittercism enableWithAppID:critterAppID];
+   }];   
 }
 
 - (void) crittercismLeaveBreadcrumb:(CDVInvokedUrlCommand *)command {

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,7 +27,6 @@
 
     <!-- ios -->
     <platform name="ios">
-        <preference name="IOS_APP_ID" />
         <config-file target="config.xml" parent="/*">
             <feature name="CDVCrittercism">
                 <param name="ios-package" value="CDVCrittercism" />
@@ -47,16 +46,11 @@
         <source-file src="platforms/ios/CrittercismSDK/libCrittercism_v5_4_1.a" framework="true" />
         <source-file src="platforms/ios/CrittercismSDK/dsym_upload.sh" />
 
-        <config-file target="*-Info.plist" parent="CritterAppID">
-            <string>$IOS_APP_ID</string>
-        </config-file>
-
         <framework src="SystemConfiguration.framework" />
     </platform>
 
     <!-- android -->
     <platform name="android">
-        <preference name="ANDROID_APP_ID" />
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="CDVCrittercism">
                 <param name="android-package" value="com.crittercism.plugin.CDVCrittercism" />
@@ -65,12 +59,8 @@
         </config-file>
 
         <source-file src="platforms/android/res/values/crittercism.xml" target-dir="res/values/" />
-        <config-file target="res/values/crittercism.xml" parent="/*">
-            <string name="cr_app_id">$ANDROID_APP_ID</string>
-        </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/*">
-            <meta-data android:name="com.crittercism.sdk.ApplicationId" android:value="@string/cr_app_id"/>
             <!-- PhoneGap adds the INTERNET permission by itself -->
             <uses-permission android:name="android.permission.READ_LOGS"/>
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>

--- a/www/js/crittercism.js
+++ b/www/js/crittercism.js
@@ -23,6 +23,11 @@ function fail () {}
 var logUnhandledExceptionAsCrash = false;
 
 var	Crittercism = {
+    init: function(appID) {
+        cordova.exec(success, fail, "CDVCrittercism", "crittercismInit", [appID]);
+        return this;
+    },
+    
     leaveBreadcrumb: function(breadCrumb) {
         cordova.exec(success, fail, "CDVCrittercism", "crittercismLeaveBreadcrumb", [breadCrumb]);
         return this;


### PR DESCRIPTION
Enhancement for https://crittercism.atlassian.net/browse/AGNT-1398

WORK DONE
- Added a PhoneGap method Crittercism.init(appID)
- Removed required IOS_APP_ID and ANDROID_APP_ID when installing PhoneGap plugin

TEST
- Installed plugin with the following command: cordova -d plugin add https://github.com/crittercism/PhoneGap#AGNT-1398-appID
- Called Crittercism.init(appID) on javascript

TEST RESULT
- App runs normally on iOS and Android without crash. Crittercism SDK was initialized normally.

@dshirley Please review
@sforen Please be very strict with my Java code