### PR TITLE
add promises in init

### DIFF
--- a/platforms/android/com/crittercism/plugin/CDVCrittercism.java
+++ b/platforms/android/com/crittercism/plugin/CDVCrittercism.java
@@ -106,7 +106,9 @@ public class CDVCrittercism extends CordovaPlugin {
             @Override
             public void run() {
                 Crittercism.initialize(context, appID);
-                callbackContext.success();
+                if (callbackContext != null) {
+                    callbackContext.success();
+                }
             }
         });
         return true;

--- a/platforms/android/com/crittercism/plugin/CDVCrittercism.java
+++ b/platforms/android/com/crittercism/plugin/CDVCrittercism.java
@@ -106,6 +106,7 @@ public class CDVCrittercism extends CordovaPlugin {
             @Override
             public void run() {
                 Crittercism.initialize(context, appID);
+                callbackContext.success();
             }
         });
         return true;

--- a/platforms/android/com/crittercism/plugin/CDVCrittercism.java
+++ b/platforms/android/com/crittercism/plugin/CDVCrittercism.java
@@ -102,13 +102,12 @@ public class CDVCrittercism extends CordovaPlugin {
         final JSONObject argsDict = args.getJSONObject(0);
         final String appID = argsDict.getString("androidAppID");
         final Context context = this.cordova.getActivity();
+        final CallbackContext myContext = callbackContext;
         executor.execute(new Runnable() {
             @Override
             public void run() {
                 Crittercism.initialize(context, appID);
-                if (callbackContext != null) {
-                    callbackContext.success();
-                }
+                myContext.success();
             }
         });
         return true;

--- a/platforms/ios/CDVCrittercism.m
+++ b/platforms/ios/CDVCrittercism.m
@@ -39,6 +39,8 @@ static NSString *const CRJavascriptXMLHttpRequest = @"JavascriptXMLHttpRequest";
      NSString* critterAppID = [argsDict objectForKey:@"iosAppID"];
      NSLog(@"Initializing Crittercism for application with app id %@", critterAppID);
      [Crittercism enableWithAppID:critterAppID];
+     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
    }];   
 }
 

--- a/www/js/crittercism.js
+++ b/www/js/crittercism.js
@@ -23,8 +23,10 @@ function fail () {}
 var logUnhandledExceptionAsCrash = false;
 
 var	Crittercism = {
-    init: function(appID) {
-        cordova.exec(success, fail, "CDVCrittercism", "crittercismInit", [appID]);
+    init: function(appID, mySuccess, myFail) {
+        if(!mySuccess) mySuccess = success;
+        if(!myFail) myFail = fail;        
+        cordova.exec(mySuccess, myFail, "CDVCrittercism", "crittercismInit", [appID]);
         return this;
     },
     


### PR DESCRIPTION
Its really a huge missing functionality not to offer any callbacks.
Because of that we don't know when Crittercism was initialized, and we can use more methods, like setUser and others. The app crashes when we don't know that.
Simple fix is adding a possiblity to add callbacks as a second param. Worth doing error callback as well, but you probably need to look into your code if any exceptions can be thrown.